### PR TITLE
env: remove git graph from reccomended extensions

### DIFF
--- a/src/pixi/.devcontainer/devcontainer.json
+++ b/src/pixi/.devcontainer/devcontainer.json
@@ -14,8 +14,7 @@
                 "jjjermiah.pixi-vscode",
                 "ms-python.python",
                 "charliermarsh.ruff",
-				"tamasfe.even-better-toml",
-                "mhutchie.git-graph"
+				"tamasfe.even-better-toml"
             ]
         }
     },

--- a/src/pixi/.devcontainer/devcontainer.json
+++ b/src/pixi/.devcontainer/devcontainer.json
@@ -14,12 +14,12 @@
                 "jjjermiah.pixi-vscode",
                 "ms-python.python",
                 "charliermarsh.ruff",
-				"tamasfe.even-better-toml"
+                "tamasfe.even-better-toml"
             ]
         }
     },
-	"features": {
-		// "ghcr.io/devcontainers/features/common-utils:2": {},
+    "features": {
+        // "ghcr.io/devcontainers/features/common-utils:2": {},
     },
     "mounts": [
         "source=${localWorkspaceFolderBasename}-pixi,target=${containerWorkspaceFolder}/.pixi,type=volume"

--- a/src/pixi/.devcontainer/devcontainer.json
+++ b/src/pixi/.devcontainer/devcontainer.json
@@ -18,9 +18,6 @@
             ]
         }
     },
-    "features": {
-        // "ghcr.io/devcontainers/features/common-utils:2": {},
-    },
     "mounts": [
         "source=${localWorkspaceFolderBasename}-pixi,target=${containerWorkspaceFolder}/.pixi,type=volume"
     ],

--- a/src/pixi/devcontainer-template.json
+++ b/src/pixi/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "pixi",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "name": "Pixi",
     "description": "A development container with Pixi pre-installed, perfect for Python, C, C++, and other workflows that can benefit from Pixi's package management.",
     "documentationURL": "https://github.com/prefix-dev/pixi",


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Remove git graph extension from reccomended extensions.